### PR TITLE
[api] 회원 가입 시 default todo list 생성

### DIFF
--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -118,6 +118,7 @@ type CreateUserSuccess {
 
   """JWT when create user success"""
   token: String!
+  todoList: TodoList!
 }
 
 type CreateUserError {
@@ -181,4 +182,5 @@ input CreateTodoItemInput {
 
 input CreateTodoListInput {
   name: String!
+  owners: [String!]!
 }

--- a/packages/api/src/todo-list/dto/create-todo-list.input.ts
+++ b/packages/api/src/todo-list/dto/create-todo-list.input.ts
@@ -1,10 +1,10 @@
-import { Field, InputType, OmitType, PartialType } from '@nestjs/graphql'
-import { TodoList } from '../entities/todo-list.entity'
+import { Field, InputType } from '@nestjs/graphql'
 
 @InputType()
-export class CreateTodoListInput extends OmitType(PartialType(TodoList), [
-  'id',
-]) {
+export class CreateTodoListInput {
   @Field(() => String)
   name: string
+
+  @Field(() => [String])
+  owners: string[]
 }

--- a/packages/api/src/todo-list/todo-list.service.ts
+++ b/packages/api/src/todo-list/todo-list.service.ts
@@ -12,8 +12,8 @@ export class TodoListService {
   ) {}
 
   async createTodoList(createTodoListInput: CreateTodoListInput) {
-    const { name } = createTodoListInput
-    return await new this.TodoListModel({ name }).save()
+    const { name, owners } = createTodoListInput
+    return await new this.TodoListModel({ name, owners, todos: [] }).save()
   }
 
   async findTodoList(id: string, ownerId: string): Promise<TodoList> {

--- a/packages/api/src/user/dto/create-user.output.ts
+++ b/packages/api/src/user/dto/create-user.output.ts
@@ -1,5 +1,6 @@
 import { createUnionType, Field, ObjectType } from '@nestjs/graphql'
 import { BaseError } from 'src/base/error.dto'
+import { TodoList } from 'src/todo-list/entities/todo-list.entity'
 import { User } from '../entities/user.entity'
 
 @ObjectType()
@@ -9,6 +10,9 @@ export class CreateUserSuccess {
 
   @Field({ description: 'JWT when create user success' })
   token: string
+
+  @Field(() => TodoList)
+  todoList: TodoList
 }
 
 @ObjectType()

--- a/packages/api/src/user/user.config.ts
+++ b/packages/api/src/user/user.config.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TODO_LIST_NAME = 'My Todos'

--- a/packages/api/src/user/user.module.ts
+++ b/packages/api/src/user/user.module.ts
@@ -1,5 +1,10 @@
 import { Module } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
+import {
+  TodoList,
+  TodoListSchema,
+} from 'src/todo-list/entities/todo-list.entity'
+import { TodoListService } from 'src/todo-list/todo-list.service'
 import { User, UserSchema } from './entities/user.entity'
 import { UserResolver } from './user.resolver'
 import { UserService } from './user.service'
@@ -7,7 +12,10 @@ import { UserService } from './user.service'
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    MongooseModule.forFeature([
+      { name: TodoList.name, schema: TodoListSchema },
+    ]),
   ],
-  providers: [UserResolver, UserService],
+  providers: [UserResolver, UserService, TodoListService],
 })
 export class UserModule {}

--- a/packages/api/src/user/user.service.ts
+++ b/packages/api/src/user/user.service.ts
@@ -67,7 +67,7 @@ export class UserService {
   async create({
     email,
     password,
-  }: CreateUserInput): Promise<CreateUserSuccess> {
+  }: CreateUserInput): Promise<Omit<CreateUserSuccess, 'todoList'>> {
     const exist = await this.userModel.findOne({ email })
     if (exist) throw `${email} is already exist`
 


### PR DESCRIPTION
## Related issues
Resolves #82

## Description
- 회원 가입 시 default todo list를 생성
- 회원 가입 mutation response에 생성된 todo list를 포함

## Test
- localhost:4000/graphql 혹은 프론트엔드를 통해 createUser muation을 실행합니다.
- 응답 값에 todoList가 포함되어 있는 것을 확인합니다.
