### PR TITLE
[web] todoList 페이지의 completed 섹션 생성

### DIFF
--- a/packages/web/components/TodoItem/TodoItem.tsx
+++ b/packages/web/components/TodoItem/TodoItem.tsx
@@ -43,28 +43,31 @@ const TodoItem = ({ todo }: Props) => {
         >
           {content}
         </Row>
-        {!!dueDateTime && isExpired ? (
-          <Row align="middle">
-            <CalendarOutlined style={{ marginRight: '0.5rem', color: 'red' }} />
-            <span
-              className={styles.dueDateTime}
-              data-checked={checked ? 'true' : 'false'}
-              style={{ color: 'red' }}
-            >
-              {dayjs(dueDateTime).format('ddd MMM D, YYYY')}
-            </span>
-          </Row>
-        ) : (
-          <Row align="middle">
-            <CalendarOutlined style={{ marginRight: '0.5rem' }} />
-            <span
-              className={styles.dueDateTime}
-              data-checked={checked ? 'true' : 'false'}
-            >
-              {dayjs(dueDateTime).format('ddd MMM D, YYYY')}
-            </span>
-          </Row>
-        )}
+        {!!dueDateTime &&
+          (isExpired ? (
+            <Row align="middle">
+              <CalendarOutlined
+                style={{ marginRight: '0.5rem', color: 'red' }}
+              />
+              <span
+                className={styles.dueDateTime}
+                data-checked={checked ? 'true' : 'false'}
+                style={{ color: 'red' }}
+              >
+                {dayjs(dueDateTime).format('ddd MMM D, YYYY')}
+              </span>
+            </Row>
+          ) : (
+            <Row align="middle">
+              <CalendarOutlined style={{ marginRight: '0.5rem' }} />
+              <span
+                className={styles.dueDateTime}
+                data-checked={checked ? 'true' : 'false'}
+              >
+                {dayjs(dueDateTime).format('ddd MMM D, YYYY')}
+              </span>
+            </Row>
+          ))}
         {!!tags.length && (
           <Row>
             <Col>

--- a/packages/web/components/TodoList/TodoList.tsx
+++ b/packages/web/components/TodoList/TodoList.tsx
@@ -1,7 +1,8 @@
 import { DownOutlined } from '@ant-design/icons'
 import { gql, useQuery } from '@apollo/client'
-import { Button } from 'antd'
-import React from 'react'
+import { TodoStatus } from '@web/lib/graphql/types'
+import { Button, List } from 'antd'
+import React, { useState } from 'react'
 import TodoItem from '../TodoItem/TodoItem'
 import { FindTodoListDocument } from './TodoList.generated'
 
@@ -29,6 +30,7 @@ export const findTodoList = gql`
 `
 
 const TodoList = ({ todoListId }: Props) => {
+  const [showCompleted, setShowCompleted] = useState<boolean>(false)
   const { loading, data, error } = useQuery(FindTodoListDocument, {
     variables: {
       id: todoListId,
@@ -39,16 +41,29 @@ const TodoList = ({ todoListId }: Props) => {
   if (data.findTodoList.__typename === 'FindTodoListError')
     return <div>{data.findTodoList.message}</div>
 
-  const todos = (data?.findTodoList.todoList.todos ?? []).map((todo) => {
-    return <TodoItem key={todo.id} todo={todo} />
-  })
-
   return (
     <div>
-      {todos}
-      <Button type="primary" icon={<DownOutlined />}>
+      <List
+        dataSource={(data?.findTodoList.todoList.todos ?? []).filter(
+          ({ status }) => status === TodoStatus.InProgress
+        )}
+        renderItem={(todo) => <TodoItem key={todo.id} todo={todo} />}
+      />
+      <Button
+        type="primary"
+        icon={<DownOutlined />}
+        onClick={() => setShowCompleted((prev) => !prev)}
+      >
         Completed
       </Button>
+      {showCompleted && (
+        <List
+          dataSource={(data?.findTodoList.todoList.todos ?? []).filter(
+            ({ status }) => status === TodoStatus.Completed
+          )}
+          renderItem={(todo) => <TodoItem key={todo.id} todo={todo} />}
+        />
+      )}
     </div>
   )
 }

--- a/packages/web/components/TodoList/TodoList.tsx
+++ b/packages/web/components/TodoList/TodoList.tsx
@@ -1,4 +1,6 @@
+import { DownOutlined } from '@ant-design/icons'
 import { gql, useQuery } from '@apollo/client'
+import { Button } from 'antd'
 import React from 'react'
 import TodoItem from '../TodoItem/TodoItem'
 import { FindTodoListDocument } from './TodoList.generated'
@@ -40,7 +42,15 @@ const TodoList = ({ todoListId }: Props) => {
   const todos = (data?.findTodoList.todoList.todos ?? []).map((todo) => {
     return <TodoItem key={todo.id} todo={todo} />
   })
-  return <div>{todos}</div>
+
+  return (
+    <div>
+      {todos}
+      <Button type="primary" icon={<DownOutlined />}>
+        Completed
+      </Button>
+    </div>
+  )
 }
 
 export default TodoList


### PR DESCRIPTION
## Related issues

Resolves #86 

## Description

- Completed 버튼을 생성하고 버튼 클릭시 `showCompleted` 상태를 토글하도록 하였습니다. 
- `status`가 `Completed`인 todo와 `InProgress`인 todo 목록을 분리하였습니다.  
- dummy data를 만들어 확인하였습니다.
```ts
const todosSample = [
  {
    id: '1',
    content: 'todo1',
    status: TodoStatus.InProgress,
    tags: [],
    dueDateTime: null,
  },
  {
    id: '2',
    content: 'todo2',
    status: TodoStatus.Completed,
    tags: [],
    dueDateTime: null,
  },
  {
    id: '3',
    content: 'todo3',
    status: TodoStatus.Completed,
    tags: [],
    dueDateTime: null,
  },
]
```
- 결과 화면
![Apr-24-2022 00-31-24](https://user-images.githubusercontent.com/77310643/164912750-73521c7a-c4b8-4e17-a7ed-3d35a38db22e.gif)

