### PR TITLE
[api] update todoitem 뮤테이션 추가

### DIFF
--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -2,28 +2,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
-type TodoItem {
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  content: String!
-  status: TodoStatus!
-  tags: [Tag!]!
-  dueDateTime: DateTime
-  todoList: TodoList!
-}
-
-"""
-A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
-"""
-scalar DateTime
-
-enum TodoStatus {
-  IN_PROGRESS
-  COMPLETED
-}
-
 type User {
   id: ID!
   createdAt: DateTime!
@@ -33,15 +11,10 @@ type User {
   lastLoginAt: DateTime
 }
 
-type TodoList {
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  name: String!
-  todos: [TodoItem!]!
-  owners: [User!]!
-}
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
 
 type Tag {
   id: ID!
@@ -58,10 +31,37 @@ type AddTagOutput {
   tag: Tag
 }
 
-type ListTagsOutput {
+type TagsOutput {
   success: Boolean!
   message: String
   tags: [Tag!]!
+}
+
+type TodoItem {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
+  content: String!
+  status: TodoStatus!
+  tags: [Tag!]!
+  dueDateTime: DateTime
+  todoList: TodoList!
+}
+
+enum TodoStatus {
+  IN_PROGRESS
+  COMPLETED
+}
+
+type TodoList {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
+  name: String!
+  todos: [TodoItem!]!
+  owners: [User!]!
 }
 
 type AddTodoListOutput {
@@ -74,7 +74,7 @@ type Query {
   me: MeOutput!
   users: [User!]!
   user(id: String!): User!
-  listTags: ListTagsOutput!
+  tags: TagsOutput!
   todoItems(todoItemsInput: TodoItemsInput!): TodoItemsOutput!
   todoItem(id: String!): TodoItem
   findTodoList(findTodoListInput: FindTodoListInput!): FindTodoListOutput!
@@ -126,6 +126,7 @@ type Mutation {
   signin(signinInput: SigninInput!): SigninOutput!
   addTag(addTagInput: AddTagInput!): AddTagOutput!
   addTodoItem(addTodoItemInput: AddTodoItemInput!): AddTodoItemOutput!
+  updateTodoItem(updateTodoItemInput: UpdateTodoItemInput!): UpdateTodoItemOutput!
   addTodoList(addTodoListInput: AddTodoListInput!): AddTodoListOutput!
 }
 
@@ -187,6 +188,27 @@ input AddTodoItemInput {
   todoListId: String!
   content: String!
   status: String
+  dueDateTime: DateTime
+}
+
+union UpdateTodoItemOutput = UpdateTodoItemSuccess | UpdateTodoItemError
+
+type UpdateTodoItemSuccess {
+  todoItem: TodoItem!
+}
+
+type UpdateTodoItemError {
+  message: String!
+}
+
+input UpdateTodoItemInput {
+  id: String!
+  update: UpdateInput!
+}
+
+input UpdateInput {
+  content: String
+  tagIds: [ID]
   dueDateTime: DateTime
 }
 

--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -11,6 +11,7 @@ type TodoItem {
   status: TodoStatus!
   tags: [Tag!]!
   dueDateTime: DateTime
+  todoList: TodoList!
 }
 
 """
@@ -61,33 +62,6 @@ type ListTagsOutput {
   success: Boolean!
   message: String
   tags: [Tag!]!
-}
-
-type TodoItem {
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  content: String!
-  status: TodoStatus!
-  tags: [Tag!]!
-  dueDateTime: DateTime
-  todoList: TodoList!
-}
-
-enum TodoStatus {
-  IN_PROGRESS
-  COMPLETED
-}
-
-type TodoList {
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  name: String!
-  todos: [TodoItem!]!
-  owners: [User!]!
 }
 
 type AddTodoListOutput {
@@ -160,9 +134,7 @@ union SignupOutput = SignupSuccess | SignupError
 type SignupSuccess {
   user: User!
 
-  """
-  JWT when create user success
-  """
+  """JWT when create user success"""
   token: String!
   todoList: TodoList!
 }
@@ -172,14 +144,10 @@ type SignupError {
 }
 
 input SignupInput {
-  """
-  user email
-  """
+  """user email"""
   email: String!
 
-  """
-  user password
-  """
+  """user password"""
   password: String!
 }
 
@@ -194,14 +162,10 @@ type SigninError {
 }
 
 input SigninInput {
-  """
-  user email
-  """
+  """user email"""
   email: String!
 
-  """
-  user password
-  """
+  """user password"""
   password: String!
 }
 

--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -2,6 +2,28 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type TodoItem {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
+  content: String!
+  status: TodoStatus!
+  tags: [Tag!]!
+  dueDateTime: DateTime
+  todoList: TodoList!
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
+enum TodoStatus {
+  IN_PROGRESS
+  COMPLETED
+}
+
 type User {
   id: ID!
   createdAt: DateTime!
@@ -11,10 +33,15 @@ type User {
   lastLoginAt: DateTime
 }
 
-"""
-A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
-"""
-scalar DateTime
+type TodoList {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
+  name: String!
+  todos: [TodoItem!]!
+  owners: [User!]!
+}
 
 type Tag {
   id: ID!
@@ -35,33 +62,6 @@ type TagsOutput {
   success: Boolean!
   message: String
   tags: [Tag!]!
-}
-
-type TodoItem {
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  content: String!
-  status: TodoStatus!
-  tags: [Tag!]!
-  dueDateTime: DateTime
-  todoList: TodoList!
-}
-
-enum TodoStatus {
-  IN_PROGRESS
-  COMPLETED
-}
-
-type TodoList {
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  name: String!
-  todos: [TodoItem!]!
-  owners: [User!]!
 }
 
 type AddTodoListOutput {

--- a/packages/api/src/tag/dto/tags.input.ts
+++ b/packages/api/src/tag/dto/tags.input.ts
@@ -1,0 +1,9 @@
+import { Field, ID, InputType } from '@nestjs/graphql'
+
+@InputType()
+class TagsInput {
+  @Field(() => [ID])
+  tagIds: string[]
+}
+
+export default TagsInput

--- a/packages/api/src/tag/dto/tags.output.ts
+++ b/packages/api/src/tag/dto/tags.output.ts
@@ -1,9 +1,11 @@
 import { Field, ObjectType } from '@nestjs/graphql'
+
 import { Output } from 'src/base/output.entity'
+
 import { Tag } from '../entities/tag.entity'
 
 @ObjectType()
-export class ListTagsOutput extends Output {
+export class TagsOutput extends Output {
   @Field(() => [Tag])
   tags?: Tag[]
 }

--- a/packages/api/src/tag/tag.resolver.ts
+++ b/packages/api/src/tag/tag.resolver.ts
@@ -2,7 +2,8 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
 
 import { AddTagInput } from './dto/add-tag.input'
 import { AddTagOutput } from './dto/add-tag.output'
-import { ListTagsOutput } from './dto/list-tags.output'
+import TagsInput from './dto/tags.input'
+import { TagsOutput } from './dto/tags.output'
 import { Tag } from './entities/tag.entity'
 import { TagService } from './tag.service'
 
@@ -27,13 +28,14 @@ export class TagResolver {
     return res
   }
 
-  @Query(() => ListTagsOutput)
-  async listTags(): Promise<ListTagsOutput> {
-    const res: ListTagsOutput = {
+  @Query(() => TagsOutput)
+  async tags(input: TagsInput): Promise<TagsOutput> {
+    const { tagIds } = input
+    const res: TagsOutput = {
       success: true,
     }
     try {
-      res.tags = await this.tagService.listTags()
+      res.tags = await this.tagService.listTags(tagIds)
     } catch (error) {
       res.success = false
       res.message = error?.message ?? ''

--- a/packages/api/src/tag/tag.service.ts
+++ b/packages/api/src/tag/tag.service.ts
@@ -18,8 +18,10 @@ export class TagService {
     return tag
   }
 
-  async listTags(): Promise<Tag[]> {
-    return await this.tagModel.find({})
+  async listTags(tagIds: string[]): Promise<Tag[]> {
+    return await this.tagModel.find({
+      _id: { $in: tagIds },
+    })
   }
 
   async listTagsByTodoList(todoListId: string): Promise<Tag[]> {

--- a/packages/api/src/todo-item/dto/update-todo-item.input.ts
+++ b/packages/api/src/todo-item/dto/update-todo-item.input.ts
@@ -1,0 +1,24 @@
+import { Field, ID, InputType, PartialType, PickType } from '@nestjs/graphql'
+
+import { TodoItem } from '../entities/todo-item.entity'
+
+@InputType()
+class UpdateInput extends PartialType(TodoItem) {
+  @Field({ nullable: true })
+  content?: string
+
+  @Field(() => [ID], { nullable: 'itemsAndList' })
+  tagIds?: string[]
+
+  @Field({ nullable: true })
+  dueDateTime?: Date
+}
+
+@InputType()
+export class UpdateTodoItemInput extends PickType(TodoItem, ['id']) {
+  @Field()
+  id: string
+
+  @Field(() => UpdateInput)
+  update: UpdateInput
+}

--- a/packages/api/src/todo-item/dto/update-todo-item.output.ts
+++ b/packages/api/src/todo-item/dto/update-todo-item.output.ts
@@ -1,0 +1,23 @@
+import { createUnionType, Field, ObjectType } from '@nestjs/graphql'
+
+import { BaseError } from 'src/base/error.dto'
+
+import { TodoItem } from '../entities/todo-item.entity'
+
+@ObjectType()
+class UpdateTodoItemSuccess {
+  @Field(() => TodoItem)
+  todoItem: TodoItem
+}
+
+@ObjectType()
+class UpdateTodoItemError extends BaseError {}
+
+export const UpdateTodoItemOutput = createUnionType({
+  name: 'UpdateTodoItemOutput',
+  types: () => [UpdateTodoItemSuccess, UpdateTodoItemError],
+  resolveType: (value) => {
+    if (value.todoItem) return UpdateTodoItemSuccess
+    return UpdateTodoItemError
+  },
+})

--- a/packages/api/src/todo-item/todo-item.resolver.ts
+++ b/packages/api/src/todo-item/todo-item.resolver.ts
@@ -9,6 +9,8 @@ import { AddTodoItemInput } from './dto/add-todo-item.input'
 import { AddTodoItemOutput } from './dto/add-todo-item.output'
 import { TodoItemsInput } from './dto/todo-itmes.input'
 import { TodoItemsError, TodoItemsOutput } from './dto/todo-itmes.output'
+import { UpdateTodoItemInput } from './dto/update-todo-item.input'
+import { UpdateTodoItemOutput } from './dto/update-todo-item.output'
 import { TodoItem } from './entities/todo-item.entity'
 import { TodoItemService } from './todo-item.service'
 
@@ -60,6 +62,24 @@ export class TodoItemResolver {
     } catch (error) {
       // todo : logging errors
       return null
+    }
+  }
+
+  @Mutation(() => UpdateTodoItemOutput)
+  async updateTodoItem(
+    @Args('updateTodoItemInput') updateTodoItemInput: UpdateTodoItemInput,
+    @CurrentUser() user?: User
+  ): Promise<typeof UpdateTodoItemOutput> {
+    try {
+      const todoItem = await this.todoService.updateTodoItem(
+        updateTodoItemInput,
+        user?.id
+      )
+      return {
+        todoItem,
+      }
+    } catch (error) {
+      return { message: error?.message ?? '' }
     }
   }
 }

--- a/packages/api/src/todo-item/todo-item.service.ts
+++ b/packages/api/src/todo-item/todo-item.service.ts
@@ -9,6 +9,7 @@ import { User } from 'src/user/entities/user.entity'
 import { AddTodoItemInput } from './dto/add-todo-item.input'
 import { TodoItemsInput } from './dto/todo-itmes.input'
 import { TodoItemsOutput } from './dto/todo-itmes.output'
+import { UpdateTodoItemInput } from './dto/update-todo-item.input'
 import { TodoDocument, TodoItem } from './entities/todo-item.entity'
 
 @Injectable()
@@ -24,7 +25,6 @@ export class TodoItemService {
       todoListId,
       content,
       status = TodoStatus.IN_PROGRESS,
-      tags = [],
       dueDateTime = null,
     }: AddTodoItemInput,
     ownerId
@@ -32,7 +32,7 @@ export class TodoItemService {
     const newTodoItem = await new this.todoItemModel({
       content,
       status,
-      tags,
+      tagIds: [],
       dueDateTime,
     }).save()
     await this.todoListService.addTodoItemToList(
@@ -42,6 +42,7 @@ export class TodoItemService {
     )
     return newTodoItem
   }
+
   async getTodoItems(
     input: TodoItemsInput,
     user: User
@@ -55,5 +56,27 @@ export class TodoItemService {
   }
   async getTodoItem(id: string): Promise<TodoItem> {
     return await this.todoItemModel.findById(id)
+  }
+
+  async updateTodoItem(
+    { id, update }: UpdateTodoItemInput,
+    ownerId
+  ): Promise<TodoItem> {
+    //TODO: Unit test for owner authorization
+    const updatedTodoItem = await this.todoItemModel
+      .findOneAndUpdate(
+        {
+          id,
+          todoList: {
+            owners: [ownerId],
+          },
+        },
+        update,
+        {
+          new: true, // Return UPDATED document
+        }
+      )
+      .exec()
+    return updatedTodoItem
   }
 }

--- a/packages/web/components/AuthForm/index.generated.ts
+++ b/packages/web/components/AuthForm/index.generated.ts
@@ -6,25 +6,31 @@ export type SigninMutationVariables = Types.Exact<{
   signinInput: Types.SigninInput
 }>
 
-export type SigninMutation = { __typename?: 'Mutation' } & {
+export type SigninMutation = {
+  __typename?: 'Mutation'
   signin:
-    | ({ __typename?: 'SigninSuccess' } & Pick<Types.SigninSuccess, 'token'>)
-    | ({ __typename?: 'SigninError' } & Pick<Types.SigninError, 'message'>)
+    | { __typename?: 'SigninError'; message: string }
+    | { __typename?: 'SigninSuccess'; token: string }
 }
 
 export type SignUpMutationVariables = Types.Exact<{
   signUpInput: Types.SignupInput
 }>
 
-export type SignUpMutation = { __typename?: 'Mutation' } & {
+export type SignUpMutation = {
+  __typename?: 'Mutation'
   signup:
-    | ({ __typename?: 'SignupSuccess' } & Pick<Types.SignupSuccess, 'token'> & {
-          user: { __typename?: 'User' } & Pick<
-            Types.User,
-            'id' | 'email' | 'lastLoginAt'
-          >
-        })
-    | ({ __typename?: 'SignupError' } & Pick<Types.SignupError, 'message'>)
+    | { __typename?: 'SignupError'; message: string }
+    | {
+        __typename?: 'SignupSuccess'
+        token: string
+        user: {
+          __typename?: 'User'
+          id: string
+          email: string
+          lastLoginAt?: any | null
+        }
+      }
 }
 
 export const SigninDocument = {

--- a/packages/web/components/TagBar/TagBar.generated.ts
+++ b/packages/web/components/TagBar/TagBar.generated.ts
@@ -1,11 +1,9 @@
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
-
-import * as Types from '../../lib/graphql/types'
-
-export type TagBar_TagFragment = { __typename?: 'Tag' } & Pick<
-  Types.Tag,
-  'id' | 'name'
->
+export type TagBar_TagFragment = {
+  __typename?: 'Tag'
+  id: string
+  name: string
+}
 
 export const TagBar_TagFragmentDoc = {
   kind: 'Document',

--- a/packages/web/components/TodoItem/TodoItem.generated.ts
+++ b/packages/web/components/TodoItem/TodoItem.generated.ts
@@ -1,11 +1,14 @@
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
 
 import * as Types from '../../lib/graphql/types'
-import { TagBar_TagFragment } from '../TagBar/TagBar.generated'
-export type TodoItem_TodoItemFragment = { __typename?: 'TodoItem' } & Pick<
-  Types.TodoItem,
-  'id' | 'content' | 'status' | 'dueDateTime'
-> & { tags: Array<{ __typename?: 'Tag' } & TagBar_TagFragment> }
+export type TodoItem_TodoItemFragment = {
+  __typename?: 'TodoItem'
+  id: string
+  content: string
+  status: Types.TodoStatus
+  dueDateTime?: any | null
+  tags: Array<{ __typename?: 'Tag'; id: string; name: string }>
+}
 
 export const TodoItem_TodoItemFragmentDoc = {
   kind: 'Document',

--- a/packages/web/components/TodoList/TodoList.generated.ts
+++ b/packages/web/components/TodoList/TodoList.generated.ts
@@ -1,30 +1,32 @@
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
 
 import * as Types from '../../lib/graphql/types'
-import { TagBar_TagFragment } from '../TagBar/TagBar.generated'
 import { TagBar_TagFragmentDoc } from '../TagBar/TagBar.generated'
-import { TodoItem_TodoItemFragment } from '../TodoItem/TodoItem.generated'
 import { TodoItem_TodoItemFragmentDoc } from '../TodoItem/TodoItem.generated'
 export type FindTodoListQueryVariables = Types.Exact<{
   input: Types.FindTodoListInput
 }>
 
-export type FindTodoListQuery = { __typename?: 'Query' } & {
+export type FindTodoListQuery = {
+  __typename?: 'Query'
   findTodoList:
-    | ({ __typename?: 'FindTodoListSuccess' } & {
-        todoList?: Types.Maybe<
-          { __typename?: 'TodoList' } & Pick<Types.TodoList, 'id'> & {
-              todos: Array<
-                { __typename?: 'TodoItem' } & TodoItem_TodoItemFragment
-              >
-            }
-        >
-        tags: Array<{ __typename?: 'Tag' } & TagBar_TagFragment>
-      })
-    | ({ __typename?: 'FindTodoListError' } & Pick<
-        Types.FindTodoListError,
-        'message'
-      >)
+    | { __typename?: 'FindTodoListError'; message: string }
+    | {
+        __typename?: 'FindTodoListSuccess'
+        todoList?: {
+          __typename?: 'TodoList'
+          id: string
+          todos: Array<{
+            __typename?: 'TodoItem'
+            id: string
+            content: string
+            status: Types.TodoStatus
+            dueDateTime?: any | null
+            tags: Array<{ __typename?: 'Tag'; id: string; name: string }>
+          }>
+        } | null
+        tags: Array<{ __typename?: 'Tag'; id: string; name: string }>
+      }
 }
 
 export const FindTodoListDocument = {

--- a/packages/web/lib/graphql/query.generated.ts
+++ b/packages/web/lib/graphql/query.generated.ts
@@ -4,12 +4,14 @@ import * as Types from './types'
 
 export type AuthPageQueryVariables = Types.Exact<{ [key: string]: never }>
 
-export type AuthPageQuery = { __typename?: 'Query' } & {
+export type AuthPageQuery = {
+  __typename?: 'Query'
   me:
-    | ({ __typename: 'MeSuccess' } & {
-        user: { __typename?: 'User' } & Pick<Types.User, 'id' | 'email'>
-      })
-    | ({ __typename: 'MeError' } & Pick<Types.MeError, 'message'>)
+    | { __typename: 'MeError'; message: string }
+    | {
+        __typename: 'MeSuccess'
+        user: { __typename?: 'User'; id: string; email: string }
+      }
 }
 
 export const AuthPageDocument = {

--- a/packages/web/lib/graphql/types.ts
+++ b/packages/web/lib/graphql/types.ts
@@ -78,13 +78,6 @@ export type FindTodoListSuccess = {
   todoList?: Maybe<TodoList>
 }
 
-export type ListTagsOutput = {
-  __typename?: 'ListTagsOutput'
-  message?: Maybe<Scalars['String']>
-  success: Scalars['Boolean']
-  tags: Array<Tag>
-}
-
 export type MeError = {
   __typename?: 'MeError'
   message: Scalars['String']
@@ -104,6 +97,7 @@ export type Mutation = {
   addTodoList: AddTodoListOutput
   signin: SigninOutput
   signup: SignupOutput
+  updateTodoItem: UpdateTodoItemOutput
 }
 
 export type MutationAddTagArgs = {
@@ -126,11 +120,15 @@ export type MutationSignupArgs = {
   signupInput: SignupInput
 }
 
+export type MutationUpdateTodoItemArgs = {
+  updateTodoItemInput: UpdateTodoItemInput
+}
+
 export type Query = {
   __typename?: 'Query'
   findTodoList: FindTodoListOutput
-  listTags: ListTagsOutput
   me: MeOutput
+  tags: TagsOutput
   todoItem?: Maybe<TodoItem>
   todoItems: TodoItemsOutput
   user: User
@@ -204,6 +202,13 @@ export type Tag = {
   updatedAt: Scalars['DateTime']
 }
 
+export type TagsOutput = {
+  __typename?: 'TagsOutput'
+  message?: Maybe<Scalars['String']>
+  success: Scalars['Boolean']
+  tags: Array<Tag>
+}
+
 export type TodoItem = {
   __typename?: 'TodoItem'
   content: Scalars['String']
@@ -249,6 +254,29 @@ export type TodoList = {
 export enum TodoStatus {
   Completed = 'COMPLETED',
   InProgress = 'IN_PROGRESS',
+}
+
+export type UpdateInput = {
+  content?: Maybe<Scalars['String']>
+  dueDateTime?: Maybe<Scalars['DateTime']>
+  tagIds?: Maybe<Array<Maybe<Scalars['ID']>>>
+}
+
+export type UpdateTodoItemError = {
+  __typename?: 'UpdateTodoItemError'
+  message: Scalars['String']
+}
+
+export type UpdateTodoItemInput = {
+  id: Scalars['String']
+  update: UpdateInput
+}
+
+export type UpdateTodoItemOutput = UpdateTodoItemError | UpdateTodoItemSuccess
+
+export type UpdateTodoItemSuccess = {
+  __typename?: 'UpdateTodoItemSuccess'
+  todoItem: TodoItem
 }
 
 export type User = {

--- a/packages/web/lib/graphql/types.ts
+++ b/packages/web/lib/graphql/types.ts
@@ -25,8 +25,8 @@ export type AddTagInput = {
 
 export type AddTagOutput = {
   __typename?: 'AddTagOutput'
-  success: Scalars['Boolean']
   message?: Maybe<Scalars['String']>
+  success: Scalars['Boolean']
   tag?: Maybe<Tag>
 }
 
@@ -36,13 +36,13 @@ export type AddTodoItemError = {
 }
 
 export type AddTodoItemInput = {
-  todoListId: Scalars['String']
   content: Scalars['String']
-  status?: Maybe<Scalars['String']>
   dueDateTime?: Maybe<Scalars['DateTime']>
+  status?: Maybe<Scalars['String']>
+  todoListId: Scalars['String']
 }
 
-export type AddTodoItemOutput = AddTodoItemSuccess | AddTodoItemError
+export type AddTodoItemOutput = AddTodoItemError | AddTodoItemSuccess
 
 export type AddTodoItemSuccess = {
   __typename?: 'AddTodoItemSuccess'
@@ -56,8 +56,8 @@ export type AddTodoListInput = {
 
 export type AddTodoListOutput = {
   __typename?: 'AddTodoListOutput'
-  success: Scalars['Boolean']
   message?: Maybe<Scalars['String']>
+  success: Scalars['Boolean']
   todoList: TodoList
 }
 
@@ -70,18 +70,18 @@ export type FindTodoListInput = {
   id: Scalars['String']
 }
 
-export type FindTodoListOutput = FindTodoListSuccess | FindTodoListError
+export type FindTodoListOutput = FindTodoListError | FindTodoListSuccess
 
 export type FindTodoListSuccess = {
   __typename?: 'FindTodoListSuccess'
-  todoList?: Maybe<TodoList>
   tags: Array<Tag>
+  todoList?: Maybe<TodoList>
 }
 
 export type ListTagsOutput = {
   __typename?: 'ListTagsOutput'
-  success: Scalars['Boolean']
   message?: Maybe<Scalars['String']>
+  success: Scalars['Boolean']
   tags: Array<Tag>
 }
 
@@ -90,7 +90,7 @@ export type MeError = {
   message: Scalars['String']
 }
 
-export type MeOutput = MeSuccess | MeError
+export type MeOutput = MeError | MeSuccess
 
 export type MeSuccess = {
   __typename?: 'MeSuccess'
@@ -99,19 +99,11 @@ export type MeSuccess = {
 
 export type Mutation = {
   __typename?: 'Mutation'
-  signup: SignupOutput
-  signin: SigninOutput
   addTag: AddTagOutput
   addTodoItem: AddTodoItemOutput
   addTodoList: AddTodoListOutput
-}
-
-export type MutationSignupArgs = {
-  signupInput: SignupInput
-}
-
-export type MutationSigninArgs = {
-  signinInput: SigninInput
+  signin: SigninOutput
+  signup: SignupOutput
 }
 
 export type MutationAddTagArgs = {
@@ -126,18 +118,30 @@ export type MutationAddTodoListArgs = {
   addTodoListInput: AddTodoListInput
 }
 
-export type Query = {
-  __typename?: 'Query'
-  me: MeOutput
-  users: Array<User>
-  user: User
-  listTags: ListTagsOutput
-  todoItems: TodoItemsOutput
-  todoItem?: Maybe<TodoItem>
-  findTodoList: FindTodoListOutput
+export type MutationSigninArgs = {
+  signinInput: SigninInput
 }
 
-export type QueryUserArgs = {
+export type MutationSignupArgs = {
+  signupInput: SignupInput
+}
+
+export type Query = {
+  __typename?: 'Query'
+  findTodoList: FindTodoListOutput
+  listTags: ListTagsOutput
+  me: MeOutput
+  todoItem?: Maybe<TodoItem>
+  todoItems: TodoItemsOutput
+  user: User
+  users: Array<User>
+}
+
+export type QueryFindTodoListArgs = {
+  findTodoListInput: FindTodoListInput
+}
+
+export type QueryTodoItemArgs = {
   id: Scalars['String']
 }
 
@@ -145,12 +149,8 @@ export type QueryTodoItemsArgs = {
   todoItemsInput: TodoItemsInput
 }
 
-export type QueryTodoItemArgs = {
+export type QueryUserArgs = {
   id: Scalars['String']
-}
-
-export type QueryFindTodoListArgs = {
-  findTodoListInput: FindTodoListInput
 }
 
 export type SigninError = {
@@ -165,7 +165,7 @@ export type SigninInput = {
   password: Scalars['String']
 }
 
-export type SigninOutput = SigninSuccess | SigninError
+export type SigninOutput = SigninError | SigninSuccess
 
 export type SigninSuccess = {
   __typename?: 'SigninSuccess'
@@ -184,24 +184,24 @@ export type SignupInput = {
   password: Scalars['String']
 }
 
-export type SignupOutput = SignupSuccess | SignupError
+export type SignupOutput = SignupError | SignupSuccess
 
 export type SignupSuccess = {
   __typename?: 'SignupSuccess'
-  user: User
+  todoList: TodoList
   /** JWT when create user success */
   token: Scalars['String']
-  todoList: TodoList
+  user: User
 }
 
 export type Tag = {
   __typename?: 'Tag'
-  id: Scalars['ID']
   createdAt: Scalars['DateTime']
-  updatedAt: Scalars['DateTime']
   deletedAt?: Maybe<Scalars['DateTime']>
+  id: Scalars['ID']
   name: Scalars['String']
   owner: User
+  updatedAt: Scalars['DateTime']
 }
 
 export type TodoItem = {
@@ -223,16 +223,16 @@ export type TodoItemsError = {
 }
 
 export type TodoItemsInput = {
-  todoListId: Scalars['ID']
   tagIds?: Maybe<Array<Scalars['ID']>>
+  todoListId: Scalars['ID']
 }
 
-export type TodoItemsOutput = TodoItemsSuccess | TodoItemsError
+export type TodoItemsOutput = TodoItemsError | TodoItemsSuccess
 
 export type TodoItemsSuccess = {
   __typename?: 'TodoItemsSuccess'
-  totalCount: Scalars['Int']
   items: Array<TodoItem>
+  totalCount: Scalars['Int']
 }
 
 export type TodoList = {
@@ -253,10 +253,10 @@ export enum TodoStatus {
 
 export type User = {
   __typename?: 'User'
-  id: Scalars['ID']
   createdAt: Scalars['DateTime']
-  updatedAt: Scalars['DateTime']
   deletedAt?: Maybe<Scalars['DateTime']>
   email: Scalars['String']
+  id: Scalars['ID']
   lastLoginAt?: Maybe<Scalars['DateTime']>
+  updatedAt: Scalars['DateTime']
 }

--- a/packages/web/pages/index.page.generated.ts
+++ b/packages/web/pages/index.page.generated.ts
@@ -4,15 +4,19 @@ import * as Types from '../lib/graphql/types'
 
 export type IndexPageQueryVariables = Types.Exact<{ [key: string]: never }>
 
-export type IndexPageQuery = { __typename?: 'Query' } & {
+export type IndexPageQuery = {
+  __typename?: 'Query'
   me:
-    | ({ __typename?: 'MeSuccess' } & {
-        user: { __typename?: 'User' } & Pick<
-          Types.User,
-          'id' | 'email' | 'lastLoginAt'
-        >
-      })
-    | ({ __typename?: 'MeError' } & Pick<Types.MeError, 'message'>)
+    | { __typename?: 'MeError'; message: string }
+    | {
+        __typename?: 'MeSuccess'
+        user: {
+          __typename?: 'User'
+          id: string
+          email: string
+          lastLoginAt?: any | null
+        }
+      }
 }
 
 export const IndexPageDocument = {


### PR DESCRIPTION
## Related issues

<!-- PR이 머지되면, 자동으로 close될 이슈 번호 -->

Resolves #98

## Description

update todoitem 뮤테이션을 추가했습니다.

## Test

- API 서버를 yarn dev로 실행
- localhost:4000/graphql을 통해 updateTodoItem 뮤테이션을 실행
- MongoDB Compass를 통해 todoItem이 업데이트 된 것을 확인


https://user-images.githubusercontent.com/68146572/170805524-f9a36770-a096-46fb-ad53-e63c37c39e07.mp4

## WIP
- Owner 필터 적용
